### PR TITLE
feat: add head-to-head collision avoidance logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ import chalk from 'chalk';
 import { preventSelfCollision } from './snakeMovement.js';
 import { avoidWalls } from './snakeMovement.js';
 import { avoidCollisionsWithOtherSnakes } from './snakeMovement.js';
-
+import { avoidHeadToHead } from './snakeMovement.js';
 // info is called when you create your Battlesnake on play.battlesnake.com
 // and controls your Battlesnake's appearance
 // TIP: If you open your Battlesnake URL in a browser you should see this data
@@ -79,6 +79,10 @@ function move(gameState) {
   // TODO: Step 3 - Prevent your Battlesnake from colliding with other Battlesnakes
   isMoveSafe = avoidCollisionsWithOtherSnakes(gameState, isMoveSafe);
 
+  // TODO: Step 4 - Prevent your Battlesnake from colliding with other Battlesnakes' heads
+  // Avoid head-to-head collisions
+  isMoveSafe = avoidHeadToHead(gameState, isMoveSafe);
+
   // Are there any safe moves left?
   const safeMoves = Object.keys(isMoveSafe).filter(key => isMoveSafe[key]);
   if (safeMoves.length == 0) {
@@ -89,7 +93,7 @@ function move(gameState) {
   // Choose a random move from the safe moves
   const nextMove = safeMoves[Math.floor(Math.random() * safeMoves.length)];
 
-  // TODO: Step 4 - Move towards food instead of random, to regain health and survive longer
+  // TODO: Step 5 - Move towards food instead of random, to regain health and survive longer
   // food = gameState.board.food;
   console.log(printBoard(gameState.board));
   console.log("The gamestate is: ", gameState);

--- a/snakeMovement.js
+++ b/snakeMovement.js
@@ -64,3 +64,42 @@ export function avoidCollisionsWithOtherSnakes(gameState, isMoveSafe) {
 
   return isMoveSafe;
 }
+
+// Todo9-Prevent head-to-head collisions with equal or longer snakes
+export function avoidHeadToHead(gameState, isMoveSafe) {
+  const myHead = gameState.you.head;
+  const myLength = gameState.you.length;
+  const directions = {
+    up:    { x: myHead.x,     y: myHead.y + 1 },
+    down:  { x: myHead.x,     y: myHead.y - 1 },
+    left:  { x: myHead.x - 1, y: myHead.y     },
+    right: { x: myHead.x + 1, y: myHead.y     },
+  };
+
+  for (const snake of gameState.board.snakes) {
+    if (snake.id === gameState.you.id) continue; // Skip self
+    const theirHead = snake.head;
+    const theirLength = snake.length;
+
+    // All possible moves their head could make
+    const theirMoves = [
+      { x: theirHead.x,     y: theirHead.y + 1 },
+      { x: theirHead.x,     y: theirHead.y - 1 },
+      { x: theirHead.x - 1, y: theirHead.y     },
+      { x: theirHead.x + 1, y: theirHead.y     },
+    ];
+
+    for (const [move, pos] of Object.entries(directions)) {
+      if (
+        isMoveSafe[move] &&
+        theirMoves.some(
+          (m) => m.x === pos.x && m.y === pos.y
+        ) &&
+        theirLength >= myLength // Only avoid if they are equal or longer
+      ) {
+        isMoveSafe[move] = false;
+      }
+    }
+  }
+  return isMoveSafe;
+}


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Description
This PR implements logic to detect and avoid head-to-head collisions between snakes. The new logic ensures safer movement decisions in scenarios where two agents may attempt to move into the same tile simultaneously.

## Related Issues
None

## Screenshots (if applicable)
Not applicable

## Additional Context
None
