### PR TITLE
feat: implement flood fill algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+
+- Implemented flood-fill algorithm for board analysis to improve safe-move selection.
 - Created and run test files for all files in `/collision` and `/movement` folders
 - Implemented a heuristic evaluation method to assess game states and improve move decisions.
 - Created sample unit tests for avoidCollisionsWithOtherSnakes logic to verify correct behavior.

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ import { avoidHeadToHead } from './snake/collisions/avoidHeadToHead.js'
 // Movement
 import { moveTowardClosestFood } from './snake/movement/moveTowardsClosestFood.js'
 import { evaluateGameState } from './snake/movement/evaluateGameState.js'
+import { filterDeadEndMoves } from './snake/movement/floodFill.js'
 
 // info is called when you create your Battlesnake on play.battlesnake.com and controls your Battlesnake's appearance
 function info() {
@@ -89,6 +90,9 @@ function move(gameState) {
 
   //  Move towards food instead of random
   isMoveSafe = moveTowardClosestFood(gameState, isMoveSafe)
+
+  //  Filter out dead-end moves
+  isMoveSafe = filterDeadEndMoves(gameState, isMoveSafe)
 
   // Are there any safe moves left?
   const safeMoves = Object.keys(isMoveSafe).filter((key) => isMoveSafe[key])

--- a/snake/movement/floodFill.js
+++ b/snake/movement/floodFill.js
@@ -1,0 +1,65 @@
+/**
+ * Compute the size of the reachable area from a given start position
+ * using flood-fill on the Battlesnake board.
+ * @param {object} board - gameState.board object (width, height, snakes, hazards)
+ * @param {{x:number,y:number}} start - Starting coordinates (e.g., after a potential move)
+ * @returns {number} - Number of reachable cells (0 if start is blocked)
+ */
+export function floodFillBoard(board, start) {
+  const { width, height, snakes, hazards = [] } = board
+  const blocked = new Set()
+  for (const snake of snakes)
+    for (const { x, y } of snake.body) blocked.add(`${x},${y}`)
+
+  for (const { x, y } of hazards) blocked.add(`${x},${y}`)
+
+  const visited = new Set()
+  const stack = [`${start.x},${start.y}`]
+  let count = 0
+
+  while (stack.length > 0) {
+    const pos = stack.pop()
+    if (visited.has(pos)) continue
+    const [x, y] = pos.split(',').map(Number)
+    if (x < 0 || x >= width || y < 0 || y >= height || blocked.has(pos))
+      continue
+    visited.add(pos)
+    count++
+    // Explore neighbors
+    stack.push(
+      `${x},${y - 1}`,
+      `${x + 1},${y}`,
+      `${x},${y + 1}`,
+      `${x - 1},${y}`
+    )
+  }
+
+  return count
+}
+
+/**
+ * Mutates isMoveSafe, marking moves that lead into dead-ends (area ≤ 1) as unsafe.
+ * @param {object} gameState - Full Battlesnake API payload
+ * @param {object} isMoveSafe - map of move => boolean
+ * @returns {object} isMoveSafe - updated map with dead-end moves removed
+ */
+export function filterDeadEndMoves(gameState, isMoveSafe) {
+  const { board, you } = gameState
+  const { x: hx, y: hy } = you.head
+  const moves = {
+    up: { x: hx, y: hy - 1 },
+    right: { x: hx + 1, y: hy },
+    down: { x: hx, y: hy + 1 },
+    left: { x: hx - 1, y: hy },
+  }
+
+  for (const [move, coord] of Object.entries(moves)) {
+    if (!isMoveSafe[move]) continue
+    const area = floodFillBoard(board, coord)
+    // treat area of 1 or 0 as dead-end
+    if (area <= 1) {
+      isMoveSafe[move] = false
+    }
+  }
+  return isMoveSafe
+}

--- a/tests/movement/floodFill.test.js
+++ b/tests/movement/floodFill.test.js
@@ -1,0 +1,55 @@
+import { floodFillBoard, filterDeadEndMoves } from '../floodFill.js'
+
+describe('floodFillBoard', () => {
+  const emptyBoard = { width: 3, height: 3, snakes: [], hazards: [] }
+
+  it('counts full area on empty board', () => {
+    expect(floodFillBoard(emptyBoard, { x: 1, y: 1 })).toBe(9)
+  })
+
+  it('returns 0 if start is blocked by snake body', () => {
+    const board = {
+      width: 2,
+      height: 2,
+      snakes: [{ body: [{ x: 0, y: 0 }] }],
+      hazards: [],
+    }
+    expect(floodFillBoard(board, { x: 0, y: 0 })).toBe(0)
+  })
+})
+
+describe('filterDeadEndMoves', () => {
+  it('marks moves into one-cell dead-ends as unsafe', () => {
+    const gameState = {
+      you: { head: { x: 1, y: 1 } },
+      board: {
+        width: 3,
+        height: 3,
+        snakes: [{ body: [{ x: 1, y: 2 }] }], // blocks down
+        hazards: [],
+      },
+    }
+    // initial safe moves all true
+    const isMoveSafe = { up: true, down: true, left: true, right: true }
+    // down blocked -> area=0, up and left/right lead to area >1 except up leads into top row with area=1
+    // Actually, snake at (1,2) blocks down. Starting up at (1,0) area <=1.
+    const result = filterDeadEndMoves(gameState, isMoveSafe)
+    expect(result.down).toBe(false) // blocked
+    expect(result.up).toBe(false) // dead-end cell at (1,0)
+    expect(result.left).toBe(true) // open
+    expect(result.right).toBe(true) // open
+  })
+
+  it('preserves already false flags', () => {
+    const gameState = {
+      you: { head: { x: 0, y: 0 } },
+      board: { width: 2, height: 2, snakes: [], hazards: [] },
+    }
+    const isMoveSafe = { up: false, right: true, down: true, left: false }
+    const res = filterDeadEndMoves(gameState, isMoveSafe)
+    expect(res.up).toBe(false)
+    expect(res.left).toBe(false)
+    expect(res.right).toBe(true)
+    expect(res.down).toBe(true)
+  })
+})


### PR DESCRIPTION
## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Description

This PR introduces a flood-fill algorithm to our Battlesnake board analysis. By computing the size of the reachable area from the snake’s head, we can make smarter move selections that avoid trapping ourselves and prioritize territory control.

## Related Issues

Closes #22 

## Screenshots (if applicable)

None applicable.

## Additional Context

Flood fill lets us:
- Quantify how much open space is available after each potential move.
- Penalize moves that lead into small “islands” of free tiles.
- Improve long-term survival and territorial advantage.