### PR TITLE
feature: add one move lookahead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Added
+- Implemented a one-move lookahead strategy using `simulateMove` and `evaluateGameState` to improve decision-making.
+- Integrated the new lookahead logic into the snake's `move` function to evaluate and score each possible move.
+- Restored the `printBoard` function for visualizing the game board during move decisions (for debugging purposes).
+
+---
+
 ## [v1.1.0] - 2025-05-20
 
 ### Added

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ import { avoidHeadToHead } from './snake/collisions/avoidHeadToHead.js'
 import { moveTowardClosestFood } from './snake/movement/moveTowardsClosestFood.js'
 import { evaluateGameState } from './snake/movement/evaluateGameState.js'
 import { filterDeadEndMoves } from './snake/movement/floodFill.js'
+import { simulateMove } from './snake/movement/simulateMove.js'
 
 // info is called when you create your Battlesnake on play.battlesnake.com and controls your Battlesnake's appearance
 function info() {
@@ -101,20 +102,30 @@ function move(gameState) {
     return { move: 'down' }
   }
 
-  evaluateGameState(gameState)
-  // Choose the first safe move
-  const nextMove = safeMoves[0]
+  // Simulate each safe move and evaluate the resulting game state
+  let bestMove = safeMoves[0] // Default to the first safe move
+  let bestScore = -Infinity
 
-  // Log the game state
-  printBoard(gameState.board)
-  console.log('The gamestate is:', gameState)
-  console.log(`MOVE ${gameState.turn}: ${nextMove}`)
-  return { move: nextMove }
+  for (const move of safeMoves) {
+    const simulatedGameState = simulateMove(gameState, move)
+    const score = evaluateGameState(simulatedGameState)
+
+    // Log the game state
+    if (score > bestScore) {
+      bestScore = score
+      bestMove = move
+    }
+  }
+
+  console.log(`MOVE ${gameState.turn}: ${bestMove} (score: ${bestScore})`)
+  printBoard(gameState.board) // Print the board for debugging
+  return { move: bestMove }
 }
+
 function printBoard(g) {
   const board = g
   const printBoard = Array.from({ length: board.height }, () =>
-    new Array(board.width).fill('.')
+    Array.from({ length: board.width }).fill('.')
   )
   for (const food of board.food) {
     printBoard[food.y][food.x] = chalk.red('F')

--- a/snake/collisions/avoidCollisionWithOtherSnakes.js
+++ b/snake/collisions/avoidCollisionWithOtherSnakes.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line sonarjs/cognitive-complexity
 export function avoidCollisionsWithOtherSnakes(gameState, isMoveSafe) {
   const myHead = gameState.you.body[0]
   const otherSnakes = gameState.board.snakes

--- a/snake/movement/simulateMove.js
+++ b/snake/movement/simulateMove.js
@@ -1,0 +1,43 @@
+export function simulateMove(gameState, move) {
+  const newGameState = structuredClone(gameState) // Deep copy the game state
+  const myHead = newGameState.you.body[0]
+
+  // Update the head position based on the move
+  switch (move) {
+    case 'up': {
+      myHead.y += 1
+      break
+    }
+    case 'down': {
+      myHead.y -= 1
+      break
+    }
+    case 'left': {
+      myHead.x -= 1
+      break
+    }
+    case 'right': {
+      myHead.x += 1
+      break
+    }
+  }
+
+  // Update the body to reflect the move
+  newGameState.you.body.unshift({ ...myHead }) // Add new head position
+  newGameState.you.body.pop() // Remove the tail
+
+  // Decrease health
+  newGameState.you.health -= 1
+
+  // Check if food is eaten
+  const foodIndex = newGameState.board.food.findIndex(
+    (food) => food.x === myHead.x && food.y === myHead.y
+  )
+  if (foodIndex !== -1) {
+    newGameState.you.body.push({ ...myHead }) // Grow the snake
+    newGameState.you.health = 100 // Reset health
+    newGameState.board.food.splice(foodIndex, 1) // Remove the eaten food
+  }
+
+  return newGameState
+}

--- a/tests/movement/floodFill.test.js
+++ b/tests/movement/floodFill.test.js
@@ -1,4 +1,7 @@
-import { floodFillBoard, filterDeadEndMoves } from '../../snake/movement/floodFill.js'
+import {
+  floodFillBoard,
+  filterDeadEndMoves,
+} from '../../snake/movement/floodFill.js'
 
 describe('floodFillBoard', () => {
   const emptyBoard = { width: 3, height: 3, snakes: [], hazards: [] }

--- a/tests/movement/simulateMove.test.js
+++ b/tests/movement/simulateMove.test.js
@@ -1,0 +1,45 @@
+import { simulateMove } from '../../snake/movement/simulateMove.js';
+
+describe('simulateMove', () => {
+  let mockGameState;
+
+  beforeEach(() => {
+    mockGameState = {
+      you: {
+        health: 90,
+        body: [
+          { x: 5, y: 5 },
+          { x: 5, y: 4 },
+          { x: 5, y: 3 },
+        ],
+      },
+      board: {
+        food: [{ x: 5, y: 6 }, { x: 0, y: 0 }],
+      },
+    };
+  });
+
+  it('should move up and update head, body, and health correctly', () => {
+    const newState = simulateMove(mockGameState, 'up');
+
+    expect(newState.you.body[0]).toEqual({ x: 5, y: 6 }); // new head
+    expect(newState.you.body.length).toBe(4); // grew because food at (5,6)
+    expect(newState.you.health).toBe(100); // reset due to eating food
+    expect(newState.board.food).toEqual([{ x: 0, y: 0 }]); // removed eaten food
+  });
+
+  it('should move left without eating and reduce health by 1', () => {
+    const newState = simulateMove(mockGameState, 'left');
+
+    expect(newState.you.body[0]).toEqual({ x: 4, y: 5 }); // new head
+    expect(newState.you.body.length).toBe(3); // no growth
+    expect(newState.you.health).toBe(89); // reduced by 1
+    expect(newState.board.food).toEqual(mockGameState.board.food); // food untouched
+  });
+
+  it('should deep clone game state (original is not mutated)', () => {
+    const originalCopy = JSON.stringify(mockGameState);
+    simulateMove(mockGameState, 'right');
+    expect(JSON.stringify(mockGameState)).toBe(originalCopy);
+  });
+});

--- a/tests/movement/simulateMove.test.js
+++ b/tests/movement/simulateMove.test.js
@@ -1,7 +1,7 @@
-import { simulateMove } from '../../snake/movement/simulateMove.js';
+import { simulateMove } from '../../snake/movement/simulateMove.js'
 
 describe('simulateMove', () => {
-  let mockGameState;
+  let mockGameState
 
   beforeEach(() => {
     mockGameState = {
@@ -14,32 +14,35 @@ describe('simulateMove', () => {
         ],
       },
       board: {
-        food: [{ x: 5, y: 6 }, { x: 0, y: 0 }],
+        food: [
+          { x: 5, y: 6 },
+          { x: 0, y: 0 },
+        ],
       },
-    };
-  });
+    }
+  })
 
   it('should move up and update head, body, and health correctly', () => {
-    const newState = simulateMove(mockGameState, 'up');
+    const newState = simulateMove(mockGameState, 'up')
 
-    expect(newState.you.body[0]).toEqual({ x: 5, y: 6 }); // new head
-    expect(newState.you.body.length).toBe(4); // grew because food at (5,6)
-    expect(newState.you.health).toBe(100); // reset due to eating food
-    expect(newState.board.food).toEqual([{ x: 0, y: 0 }]); // removed eaten food
-  });
+    expect(newState.you.body[0]).toEqual({ x: 5, y: 6 }) // new head
+    expect(newState.you.body.length).toBe(4) // grew because food at (5,6)
+    expect(newState.you.health).toBe(100) // reset due to eating food
+    expect(newState.board.food).toEqual([{ x: 0, y: 0 }]) // removed eaten food
+  })
 
   it('should move left without eating and reduce health by 1', () => {
-    const newState = simulateMove(mockGameState, 'left');
+    const newState = simulateMove(mockGameState, 'left')
 
-    expect(newState.you.body[0]).toEqual({ x: 4, y: 5 }); // new head
-    expect(newState.you.body.length).toBe(3); // no growth
-    expect(newState.you.health).toBe(89); // reduced by 1
-    expect(newState.board.food).toEqual(mockGameState.board.food); // food untouched
-  });
+    expect(newState.you.body[0]).toEqual({ x: 4, y: 5 }) // new head
+    expect(newState.you.body.length).toBe(3) // no growth
+    expect(newState.you.health).toBe(89) // reduced by 1
+    expect(newState.board.food).toEqual(mockGameState.board.food) // food untouched
+  })
 
   it('should deep clone game state (original is not mutated)', () => {
-    const originalCopy = JSON.stringify(mockGameState);
-    simulateMove(mockGameState, 'right');
-    expect(JSON.stringify(mockGameState)).toBe(originalCopy);
-  });
-});
+    const originalCopy = JSON.stringify(mockGameState)
+    simulateMove(mockGameState, 'right')
+    expect(JSON.stringify(mockGameState)).toBe(originalCopy)
+  })
+})


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix  
- [x] New feature  
- [ ] Code refactor  
- [ ] Documentation update  
- [ ] Other (please describe):  

## Description
This pull request introduces a new feature that implements a **one-move lookahead** for the Battlesnake. The `simulateMove` function is used to simulate the game state for each possible move, and the `evaluateGameState` function scores the resulting game state. The move with the highest score is selected as the best move. This ensures the Battlesnake makes more informed decisions by considering the immediate consequences of its actions.

## Related Issues
Closes #47

## Screenshots (if applicable)
Not Applicable

## Additional Context
- This implementation only looks one move ahead. Future enhancements could include multi-move lookahead (e.g., minimax or depth-based strategies).
- The heuristic evaluation is basic and may need refinement for more complex scenarios.