### PR TITLE
feat: add royale game mode logic 

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,9 @@ import { evaluateGameState } from './snake/movement/evaluateGameState.js'
 import { filterDeadEndMoves } from './snake/movement/floodFill.js'
 import { simulateMove } from './snake/movement/simulateMove.js'
 
+// Game Modes
+import { avoidHazards } from './snake/modes/royale.js' //For royale mode
+
 /**
  * @function info
  * @description Returns object with information about your Battlesnake. This function is called when you create your Battlesnake on play.battlesnake.com and controls your Battlesnake's appearance.
@@ -125,6 +128,9 @@ function move(gameState) {
 
   //  Filter out dead-end moves
   isMoveSafe = filterDeadEndMoves(gameState, isMoveSafe)
+
+  // Royale mode: avoid entering hazards
+  isMoveSafe = avoidHazards(gameState, isMoveSafe)
 
   // Are there any safe moves left?
   const safeMoves = Object.keys(isMoveSafe).filter((key) => isMoveSafe[key])

--- a/snake/modes/royale.js
+++ b/snake/modes/royale.js
@@ -1,0 +1,54 @@
+// snake/modes/royale.js
+
+/**
+ * Check if the game is in Royale mode.
+ * @param {object} gameState
+ * @returns {boolean}
+ */
+export function isRoyaleMode(gameState) {
+  return Boolean(gameState.rulesetSettings?.royale?.shrinkEveryNTurns)
+}
+
+/**
+ * Avoid moving into hazard tiles in Royale mode, unless health is sufficient.
+ * @param {object} gameState
+ * @param {object} isMoveSafe
+ * @returns {object}
+ */
+export function avoidHazards(gameState, isMoveSafe) {
+  if (!isRoyaleMode(gameState)) return isMoveSafe
+
+  const hazards = gameState.board.hazards || []
+  const head = gameState.you.body[0]
+  const health = gameState.you.health
+  const hazardDamage =
+    gameState.rulesetSettings.royale?.hazardDamagePerTurn || 14
+
+  const getNextPosition = (dir) => {
+    switch (dir) {
+      case 'up': {
+        return { x: head.x, y: head.y + 1 }
+      }
+      case 'down': {
+        return { x: head.x, y: head.y - 1 }
+      }
+      case 'left': {
+        return { x: head.x - 1, y: head.y }
+      }
+      case 'right': {
+        return { x: head.x + 1, y: head.y }
+      }
+    }
+  }
+
+  for (const direction of Object.keys(isMoveSafe)) {
+    if (!isMoveSafe[direction]) continue
+    const next = getNextPosition(direction)
+    const isHazard = hazards.some((h) => h.x === next.x && h.y === next.y)
+    if (isHazard && health <= hazardDamage + 1) {
+      isMoveSafe[direction] = false
+    }
+  }
+
+  return isMoveSafe
+}

--- a/tests/modes/royale.test.js
+++ b/tests/modes/royale.test.js
@@ -1,0 +1,82 @@
+import { avoidHazards } from '../../snake/modes/royale.js'
+
+describe('Royale Mode - avoidHazards()', () => {
+  const baseGameState = {
+    rulesetSettings: {
+      royale: {
+        shrinkEveryNTurns: 10,
+        hazardDamagePerTurn: 14,
+      },
+    },
+    you: {
+      id: 'me',
+      health: 15,
+      body: [{ x: 2, y: 2 }],
+    },
+    board: {
+      hazards: [],
+      snakes: [],
+    },
+  }
+
+  it('does nothing if not in Royale mode', () => {
+    const state = { ...baseGameState, rulesetSettings: {} }
+    const isMoveSafe = { up: true, down: true, left: true, right: true }
+    const result = avoidHazards(state, { ...isMoveSafe })
+    expect(result).toEqual(isMoveSafe)
+  })
+
+  it('blocks move into hazard when health too low', () => {
+    const state = {
+      ...baseGameState,
+      board: {
+        hazards: [{ x: 3, y: 2 }],
+        snakes: [],
+      },
+      you: { ...baseGameState.you, health: 15 },
+    }
+
+    const isMoveSafe = { up: true, down: true, left: true, right: true }
+    const result = avoidHazards(state, { ...isMoveSafe })
+
+    expect(result.right).toBe(false)
+    expect(result.left).toBe(true)
+    expect(result.up).toBe(true)
+    expect(result.down).toBe(true)
+  })
+
+  it('allows move into hazard when health is high enough', () => {
+    const state = {
+      ...baseGameState,
+      you: { ...baseGameState.you, health: 20 },
+      board: {
+        hazards: [{ x: 3, y: 2 }],
+        snakes: [],
+      },
+    }
+
+    const isMoveSafe = { up: true, down: true, left: true, right: true }
+    const result = avoidHazards(state, { ...isMoveSafe })
+
+    expect(result.right).toBe(true)
+  })
+
+  it('does not block non-hazard directions', () => {
+    const state = {
+      ...baseGameState,
+      you: { ...baseGameState.you, health: 10 },
+      board: {
+        hazards: [{ x: 3, y: 2 }],
+        snakes: [],
+      },
+    }
+
+    const isMoveSafe = { up: true, down: true, left: true, right: true }
+    const result = avoidHazards(state, { ...isMoveSafe })
+
+    expect(result.left).toBe(true)
+    expect(result.up).toBe(true)
+    expect(result.down).toBe(true)
+    expect(result.right).toBe(false) // hazard
+  })
+})


### PR DESCRIPTION
## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Description

Adds support for Battlesnake Royale mode by introducing logic that detects Royale-specific settings and avoids hazard tiles when health is too low. The implementation is modular and cleanly separated into a new `snake/modes/royale.js` file.

Key changes:
- Introduced `avoidHazards()` to handle hazard-aware movement logic
- Integrated the logic into `index.js` safely, gated by a Royale mode check
- Added Jest tests in `tests/modes/royale.test.js` to verify behavior
- Ensures hazard logic is only applied when `rulesetSettings.royale` is active

This change allows the snake to participate in Royale matches while preserving behavior in other game modes.

## Related Issues

Closes #35 

## Screenshots (if applicable)

Non Applicable.

## Additional Context

This implementation is made using test driven development and is designed in such a way that it does not interfere with standard game mode behavior.
